### PR TITLE
Added UMD support

### DIFF
--- a/wNumb.js
+++ b/wNumb.js
@@ -13,7 +13,7 @@
     } else {
 
         // Browser globals
-        window.noUiSlider = factory();
+        window.wNumb = factory();
     }
 
 }(function(){

--- a/wNumb.js
+++ b/wNumb.js
@@ -1,4 +1,22 @@
-(function(){
+(function (factory) {
+
+    if ( typeof define === 'function' && define.amd ) {
+
+        // AMD. Register as an anonymous module.
+        define([], factory);
+
+    } else if ( typeof exports === 'object' ) {
+
+        // Node/CommonJS
+        module.exports = factory();
+
+    } else {
+
+        // Browser globals
+        window.noUiSlider = factory();
+    }
+
+}(function(){
 
 	'use strict';
 
@@ -330,6 +348,6 @@ var
 	}
 
 	/** @export */
-	window.wNumb = wNumb;
+	return wNumb;
 
-}());
+}));


### PR DESCRIPTION
Went to use this with noUiSlider and realized that `require('wnumb')` was returning an empty object, so I copied [the UMD patten from noUiSlider](https://github.com/leongersen/noUiSlider/blob/363822d16bb737529f298478c6c67945400021e9/src/js/intro.js).

Hope this is a quick fix for anyone else out there using Browserify.