### PR TITLE
Add an option for rounding numbers with optional decimals

### DIFF
--- a/test.html
+++ b/test.html
@@ -164,4 +164,22 @@
 			equal ( Tester.to ( 1058009 ), '1058009m' );
 		});
 
+		test( "Testing round", function(){
+
+			var Tester = wNumb({
+				round: 1000000,
+				decimals: 2,
+				postfix: 'm'
+			});
+
+			equal ( Tester.to(8550405), '8.55m');
+			equal (Tester.from('8.55m'), 8550000);
+
+			equal ( Tester.to(3971883), '3.97m');
+			equal ( Tester.from('3.97m'), 3970000);
+
+			equal ( Tester.to(2296224), '2.30m');
+			equal ( Tester.from('2.30m'), 2300000);
+		})
+
 	</script>

--- a/wNumb.js
+++ b/wNumb.js
@@ -27,6 +27,7 @@ var
 	'mark',
 	'prefix',
 	'postfix',
+	'round',
 	'encoder',
 	'decoder',
 	'negativeBefore',
@@ -74,7 +75,7 @@ var
 // Formatting
 
 	// Accept a number as input, output formatted string.
-	function formatTo ( decimals, thousand, mark, prefix, postfix, encoder, decoder, negativeBefore, negative, edit, undo, input ) {
+	function formatTo ( decimals, thousand, mark, prefix, postfix, round, encoder, decoder, negativeBefore, negative, edit, undo, input ) {
 
 		var originalInput = input, inputIsNegative, inputPieces, inputBase, inputDecimals = '', output = '';
 
@@ -100,6 +101,21 @@ var
 		if ( input < 0 ) {
 			inputIsNegative = true;
 			input = Math.abs(input);
+		}
+
+		// Round the input to the specified number
+		if ( round ) {
+			// If decimals required, round to requested number divided by
+			// 10^decimal places, then divide by 10^decimal places
+			if (decimals) {
+				var scaling = Math.pow(10, decimals);
+				input = Math.round(input / (round / scaling)) / scaling;
+			} else {
+				// If no decimal is needed, round directly
+				input = Math.round(input / round);
+			}
+
+
 		}
 
 		// Reduce the number of decimals to the specified option.
@@ -166,7 +182,7 @@ var
 	}
 
 	// Accept a sting as input, output decoded number.
-	function formatFrom ( decimals, thousand, mark, prefix, postfix, encoder, decoder, negativeBefore, negative, edit, undo, input ) {
+	function formatFrom ( decimals, thousand, mark, prefix, postfix, round, encoder, decoder, negativeBefore, negative, edit, undo, input ) {
 
 		var originalInput = input, inputIsNegative, output = '';
 
@@ -233,6 +249,10 @@ var
 		// Covert to number.
 		output = Number(output);
 
+		if ( round ) {
+			output = output * round;
+		}
+
 		// Run the user-specified post-decoder.
 		if ( decoder ) {
 			output = decoder(output);
@@ -274,7 +294,15 @@ var
 
 			// Floating points in JS are stable up to 7 decimals.
 			} else if ( optionName === 'decimals' ) {
-				if ( optionValue >= 0 && optionValue < 8 ) {
+				if (optionValue >= 0 && optionValue < 8) {
+					filteredOptions[optionName] = optionValue;
+				} else {
+					throw new Error(optionName);
+				}
+
+			// Rounding must be positive
+			} else if ( optionName === 'round' ) {
+				if ( optionValue >= 0 ) {
 					filteredOptions[optionName] = optionValue;
 				} else {
 					throw new Error(optionName);


### PR DESCRIPTION
Adds an option for rounding numbers.
For example, with a round option of 1000 and decimals of 2, will convert 8767 to 8.77. I added tests as well.
I found a need for this while using noUiSlider on a project with large values (city populations) that were causing the markers on pips to overlap.
